### PR TITLE
upgrade package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-jest": "^24.1.3",
-    "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.11",
+    "webpack": "^5.40.0",
+    "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.10.3"
   },
   "dependencies": {


### PR DESCRIPTION
Hello, thank you your webpack-react repository, you helped me at my project :)
I needed a little webpack package upgrade at my project and i found a little issue.

[https://github.com/webpack/webpack-dev-server/issues/2029#issuecomment-707196728](https://github.com/webpack/webpack-dev-server/issues/2029#issuecomment-707196728)

NPM package.json scripts are a convenient and useful means to run locally installed binaries without having to be concerned about their full paths. Simply define a script as such:

For webpack-cli 3.x:
"scripts": {
  "start:dev": "webpack-dev-server"
}

For webpack-cli 4.x:

"scripts": {
  "start:dev": "webpack serve"
}

In this case, your version contains:
    "webpack": "^4.43.0",
    "webpack-cli": "^3.3.11",

and when I installed manually the dev dependencies, these packages are newest:
    "webpack": "^5.40.0",
    "webpack-cli": "^4.7.2",